### PR TITLE
User can view list of all pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,8 @@
 class PagesController < ApplicationController
+  def index
+    @pages = Page.all
+  end
+
   def show
     @page = Page.find(params[:id])
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,2 +1,5 @@
 class Page < ApplicationRecord
+  def to_param
+    "#{id}-#{slug}"
+  end
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,0 +1,15 @@
+<h1> List of all Pages </h1>
+
+<table>
+  <tr>
+    <th>Title</th>
+    <th></th>
+  </tr>
+
+  <% @pages.each do |page| %>
+    <tr>
+      <td><%= page.title %></td>
+      <td><%= link_to 'Show', page_path(page), data: { slug: page.slug } %></td>
+    </tr>
+  <% end %>
+</table>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,6 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Page.create(title: "index", content: "<h1>index</h1>", slug: "index")
+if ENV["RAILS_ENV"] == "development"
+  Page.create(title: "index", content: "<h1>index</h1>", slug: "index")
+end

--- a/spec/features/user_can_navigate_to_specific_page_from_index_page_spec.rb
+++ b/spec/features/user_can_navigate_to_specific_page_from_index_page_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "User can navigate to a specific page from the index page" do
+  context "When a page exists" do
+    scenario "the index page's show link targets the associated page" do
+      test_page = Page.create(title: "test title", content: "test content", slug: "test-slug")
+
+      visit pages_path
+      click_link "Show"
+
+      expect(page).to have_content(test_page.title)
+      expect(page).to have_content(test_page.content)
+    end
+  end
+
+  context "When multiple pages exist" do
+    scenario "the index page's show links target the associated page" do
+      Page.create(title: "test title one", content: "test content one", slug: "test-slug-one")
+      test_page_two = Page.create(title: "test title two", content: "test content two", slug: "test-slug-two")
+      Page.create(title: "test title three", content: "test content three", slug: "test-slug-three")
+
+      visit pages_path
+
+      find('a[data-slug="test-slug-two"]').click
+      expect(page).to have_content(test_page_two.title)
+      expect(page).to have_content(test_page_two.content)
+    end
+  end
+end

--- a/spec/features/user_can_see_list_of_all_pages_spec.rb
+++ b/spec/features/user_can_see_list_of_all_pages_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "User can see list of all pages" do
+  context "When a page exists" do
+    scenario "the index page shows the page's title" do
+      test_page = Page.create(title: "test title", content: "test content", slug: "test-slug")
+
+      visit pages_path
+
+      expect(page).to have_content("List of all Pages")
+      expect(page).to have_content(test_page.title)
+      expect(page).to have_content("Show")
+    end
+  end
+
+  context "When multiple pages exist" do
+    scenario "the index page shows all the page titles" do
+      test_page_one = Page.create(title: "test title one", content: "test content one", slug: "test-slug-one")
+      test_page_two = Page.create(title: "test title two", content: "test content two", slug: "test-slug-two")
+      test_page_three = Page.create(title: "test title three", content: "test content three", slug: "test-slug-three")
+
+      visit pages_path
+
+      expect(page).to have_content("List of all Pages")
+      expect(page).to have_content(test_page_one.title)
+      expect(page).to have_content(test_page_two.title)
+      expect(page).to have_content(test_page_three.title)
+      expect(page).to have_content("Show")
+    end
+  end
+end


### PR DESCRIPTION
This index page currently just displays all the pages with a link to
the show action page for each page.

<img width="281" alt="Screenshot 2020-06-11 at 12 08 17" src="https://user-images.githubusercontent.com/59832893/84378573-4b239780-abdc-11ea-901c-70b15b5ba416.png">
