### PR TITLE
User can delete a page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,7 +35,14 @@ class PagesController < ApplicationController
     end
   end
 
+  def destroy
+    @page = Page.find(params[:id])
+    @page.destroy
+
+    redirect_to pages_path
+  end
+
   def page_params
-    params.require(:page).permit(:title, :content)
+    params.require(:page).permit(:title, :content, :slug)
   end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -4,6 +4,11 @@
     <%= form.label :title %><br>
     <%= form.text_field :title %>
   </p>
+  
+  <p>
+    <%= form.label :slug %><br>
+    <%= form.text_field :slug %>
+ </p>
 
   <p>
     <%= form.label :content %><br>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -9,7 +9,16 @@
   <% @pages.each do |page| %>
     <tr>
       <td><%= page.title %></td>
-      <td><%= link_to 'Show', page_path(page), data: { slug: page.slug } %></td>
+      <td>
+        <%= form_with model: page, method: :get, local: true do |form| %>
+          <% form.submit "Show", data: { slug: page.slug, action: "show" } %>
+        <% end %>
+      </td>
+      <td>
+        <%= form_with model: page, method: :delete, local: true do |form| %>
+          <% form.submit "Delete", data: { slug: page.slug, action: "delete" } %>
+        <% end %>
+      </td>
     </tr>
   <% end %>
 </table>

--- a/spec/features/user_can_delete_page_spec.rb
+++ b/spec/features/user_can_delete_page_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.feature "User can delete a page" do
+  context "When a page exists" do
+    scenario "the destroy action removes it from the database" do
+      test_page_one = Page.create(title: "test title one", content: "test content one", slug: "test-slug-one")
+      test_page_two = Page.create(title: "test title two", content: "test content two", slug: "test-slug-two")
+
+      visit pages_path
+
+      expect(page).to have_content(test_page_one.title)
+      expect(page).to have_content(test_page_two.title)
+
+      find('input[type="submit"][data-slug="test-slug-two"][data-action="delete"]').click
+
+      expect(page).to have_content(test_page_one.title)
+      expect(page).not_to have_content(test_page_two.title)
+    end
+  end
+end

--- a/spec/features/user_can_navigate_to_specific_page_from_index_page_spec.rb
+++ b/spec/features/user_can_navigate_to_specific_page_from_index_page_spec.rb
@@ -1,18 +1,6 @@
 require "rails_helper"
 
 RSpec.feature "User can navigate to a specific page from the index page" do
-  context "When a page exists" do
-    scenario "the index page's show link targets the associated page" do
-      test_page = Page.create(title: "test title", content: "test content", slug: "test-slug")
-
-      visit pages_path
-      click_link "Show"
-
-      expect(page).to have_content(test_page.title)
-      expect(page).to have_content(test_page.content)
-    end
-  end
-
   context "When multiple pages exist" do
     scenario "the index page's show links target the associated page" do
       Page.create(title: "test title one", content: "test content one", slug: "test-slug-one")
@@ -21,7 +9,8 @@ RSpec.feature "User can navigate to a specific page from the index page" do
 
       visit pages_path
 
-      find('a[data-slug="test-slug-two"]').click
+      find('input[type="submit"][data-slug="test-slug-two"][data-action="show"]').click
+
       expect(page).to have_content(test_page_two.title)
       expect(page).to have_content(test_page_two.content)
     end

--- a/spec/features/user_can_see_list_of_all_pages_spec.rb
+++ b/spec/features/user_can_see_list_of_all_pages_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "User can see list of all pages" do
 
       expect(page).to have_content("List of all Pages")
       expect(page).to have_content(test_page.title)
-      expect(page).to have_content("Show")
+      expect(page).to have_button("Show")
+      expect(page).to have_button("Delete")
     end
   end
 
@@ -25,7 +26,8 @@ RSpec.feature "User can see list of all pages" do
       expect(page).to have_content(test_page_one.title)
       expect(page).to have_content(test_page_two.title)
       expect(page).to have_content(test_page_three.title)
-      expect(page).to have_content("Show")
+      expect(page).to have_button("Show")
+      expect(page).to have_button("Delete")
     end
   end
 end


### PR DESCRIPTION
**Changes Made:**

- The destroy action has been added.
- The functionality is within a form_with to enable this to work without Javascript.
- Ensured consistency on the index page by putting the Show functionality within a form_with too.
- These are displayed as buttons instead of links. 
<img width="264" alt="Screenshot 2020-06-17 at 16 17 28" src="https://user-images.githubusercontent.com/59832893/84917039-b8409c80-b0b6-11ea-8d12-f9e40eebfbe5.png">

- Slugs are now set manually within the New and Edit action pages.

<img width="264" alt="Screenshot 2020-06-17 at 16 15 35" src="https://user-images.githubusercontent.com/59832893/84917051-bbd42380-b0b6-11ea-8cea-abd9809789d6.png">

<img width="317" alt="Screenshot 2020-06-17 at 16 24 53" src="https://user-images.githubusercontent.com/59832893/84917354-1ec5ba80-b0b7-11ea-87b4-08b31f5f882c.png">
