### PR TITLE
Set validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem "shoulda-matchers"
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.3.0)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -252,6 +254,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   standard

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,6 @@
 class Page < ApplicationRecord
+  validates_presence_of :content, :slug
+
   def to_param
     "#{id}-#{slug}"
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,5 +1,7 @@
 class Page < ApplicationRecord
   validates_presence_of :content, :slug
+  validates :slug, format: {without: /[^\w-]/,
+                            message: "only supports alphanumeric and - characters"}
 
   def to_param
     "#{id}-#{slug}"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -6,5 +6,29 @@ RSpec.describe Page, type: :model do
   describe "validations" do
     it { should validate_presence_of(:content) }
     it { should validate_presence_of(:slug) }
+
+    context "When a slug contains a space" do
+      it "is not valid" do
+        expect(Page.new).not_to allow_value("the is a bad slug").for(:slug)
+      end
+    end
+
+    context "When a slug contains a question mark" do
+      it "is not valid" do
+        expect(Page.new).not_to allow_value("slug??").for(:slug)
+      end
+    end
+
+    context "When a slug only contains word characters" do
+      it "is valid" do
+        expect(Page.new).to allow_value("thisisaslug").for(:slug)
+      end
+    end
+
+    context "When a slug contains dashes" do
+      it "is valid" do
+        expect(Page.new).to allow_value("this-is-a-slug").for(:slug)
+      end
+    end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Page, type: :model do
+  subject { Page.create(title: "test title", content: "test content", slug: "test-slug") }
+
+  describe "validations" do
+    it { should validate_presence_of(:content) }
+    it { should validate_presence_of(:slug) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
**Changes Made:**

- Set up shoulda-matchers for validation tests
- Set validations for content and slug
- Set conditions for the slug validation

Slugs are now only valid in this format:`i-am-the-valid-format`